### PR TITLE
Add explicit types in transpile ts sources

### DIFF
--- a/packages/jco-transpile/src/common.ts
+++ b/packages/jco-transpile/src/common.ts
@@ -5,6 +5,7 @@ import {
     writeFile,
     rm,
     mkdtemp,
+    FileHandle,
 } from 'node:fs/promises';
 import { spawn } from 'node:child_process';
 import { platform, argv0 } from 'node:process';
@@ -20,13 +21,19 @@ const DEFAULT_SIGNIFICANT_DIGITS = 4;
 /** Nubmer of bytes in a kilobyte */
 const BYTES_MAGNITUDE = 1024;
 
+export type FileBytes = Record<string, Uint8Array>;
+
+export interface SizeStrOptions {
+    significantDigits?: number;
+}
+
 /**
  * Convert a given number into the string that would appropriately represent it,
  * in either KiB or MiB.
  *
  * @param {number} num
  */
-export function sizeStr(num, opts) {
+export function sizeStr(num: number, opts?: SizeStrOptions): string {
     const significantDigits =
         opts?.significantDigits ?? DEFAULT_SIGNIFICANT_DIGITS;
     num /= BYTES_MAGNITUDE;
@@ -53,7 +60,7 @@ export function sizeStr(num, opts) {
  * @param {number} maxChars - character limit
  * @returns {string} The number, displayed
  */
-export function fixedDigitDisplay(num, maxChars) {
+export function fixedDigitDisplay(num: number, maxChars: number): string {
     const significantDigits = String(num).split('.')[0].length;
     let str;
     if (significantDigits >= maxChars - 1) {
@@ -76,7 +83,10 @@ export function fixedDigitDisplay(num, maxChars) {
  * @param {string[]} align - preferred alignment of cells
  * @returns {string} Tabulated data
  */
-export function table(data, cellAlignment = []) {
+export function table(
+    data: any[][],
+    cellAlignment: string[] = []
+): string {
     if (data.length === 0) {
         return '';
     }
@@ -106,7 +116,7 @@ export function table(data, cellAlignment = []) {
  *
  * @return {Promise<string>} A Promise that resolves to the created temporary directory
  */
-export async function getTmpDir() {
+export async function getTmpDir(): Promise<string> {
     return await mkdtemp(normalize(tmpdir() + sep));
 }
 
@@ -116,7 +126,10 @@ export async function getTmpDir() {
  * @param {string} file - file to read
  * @param {string} encoding - encoding of the file
  */
-export async function readFile(file, encoding) {
+export async function readFile(
+    file: string | Buffer | URL | FileHandle,
+    encoding?: BufferEncoding
+): Promise<Buffer | string> {
     try {
         return await fsReadFile(file, encoding);
     } catch {
@@ -132,7 +145,11 @@ export async function readFile(file, encoding) {
  * @param {string} input - wasm input to write to a temporary input file
  * @param {string[]} args
  */
-export async function runWASMTransformProgram(cmd, input, args) {
+export async function runWASMTransformProgram(
+    cmd: string,
+    input: Uint8Array,
+    args: string[]
+): Promise<Buffer> {
     const tmpDir = await getTmpDir();
     try {
         const inFile = resolve(tmpDir, 'in.wasm');
@@ -173,7 +190,7 @@ export async function runWASMTransformProgram(cmd, input, args) {
  * @param {number} val
  * @returns {number}
  */
-export function byteLengthLEB128(val) {
+export function byteLengthLEB128(val: number): number {
     let len = 0;
     do {
         val >>>= 7;

--- a/packages/jco-transpile/src/opt.ts
+++ b/packages/jco-transpile/src/opt.ts
@@ -5,6 +5,18 @@ import { byteLengthLEB128, runWASMTransformProgram } from './common.js';
 import { $init, tools } from '../vendor/wasm-tools.js';
 const { metadataShow, print } = tools;
 
+export interface OptimizeOptions {
+    quiet: boolean;
+    asyncify?: boolean;
+    optArgs?: string[];
+    noVerify?: boolean;
+}
+
+export interface OptimizeResult {
+    component: Uint8Array;
+    compressionInfo: { beforeBytes: number; afterBytes: number }[];
+}
+
 /**
  * @typedef {{
  *  quiet: boolean,
@@ -28,7 +40,10 @@ const { metadataShow, print } = tools;
  * @param {OptimizeOptions} [opts]
  * @returns {Promise<OptimizeResult>}
  */
-export async function runOptimizeComponent(componentBytes, opts) {
+export async function runOptimizeComponent(
+    componentBytes: Uint8Array,
+    opts?: OptimizeOptions
+): Promise<OptimizeResult> {
     await $init;
 
     let componentMetadata = metadataShow(componentBytes);
@@ -190,7 +205,10 @@ export async function runOptimizeComponent(componentBytes, opts) {
  * @param {Array<string>} args
  * @returns {Promise<Uint8Array>}
  */
-async function runWasmOptCLI(source, args) {
+async function runWasmOptCLI(
+    source: Uint8Array,
+    args: string[]
+): Promise<Uint8Array> {
     const wasmOptPath = fileURLToPath(
         import.meta.resolve('binaryen/bin/wasm-opt')
     );

--- a/packages/jco-transpile/src/typegen.ts
+++ b/packages/jco-transpile/src/typegen.ts
@@ -8,6 +8,22 @@ import {
 import { isWindows } from './common.js';
 import { ASYNC_WASI_IMPORTS, ASYNC_WASI_EXPORTS } from './constants.js';
 
+export interface TypeGenerationOptions {
+    name?: string;
+    worldName?: string;
+    instantiation?: 'async' | 'sync';
+    tlaCompat?: boolean;
+    asyncMode?: string;
+    asyncImports?: string[];
+    asyncExports?: string[];
+    outDir?: string;
+    features?: string[] | 'all';
+    allFeatures?: boolean;
+    asyncWasiImports?: boolean;
+    asyncWasiExports?: boolean;
+    guest?: boolean;
+}
+
 /**
  * @typedef {{
  *   name?: string,
@@ -33,7 +49,10 @@ import { ASYNC_WASI_IMPORTS, ASYNC_WASI_EXPORTS } from './constants.js';
  * @param {import('./typegen.js').TypeGenerationOptions} opts - options for controlling type generation
  * @returns {Promise<import('./common.js').FileBytes>} A Promise that resolves when all files have been written
  */
-export async function generateHostTypes(witPath, opts) {
+export async function generateHostTypes(
+    witPath: string,
+    opts: TypeGenerationOptions
+): Promise<import('./common.js').FileBytes> {
     return await runTypesComponent(witPath, opts);
 }
 
@@ -44,7 +63,10 @@ export async function generateHostTypes(witPath, opts) {
  * @param {TypeGenerationOptions} opts - options for controlling type generation
  * @returns {Promise<import('./common.js').FileBytes>} A Promise that resolves when all files have been written
  */
-export async function generateGuestTypes(witPath, opts) {
+export async function generateGuestTypes(
+    witPath: string,
+    opts: TypeGenerationOptions
+): Promise<import('./common.js').FileBytes> {
     return await runTypesComponent(witPath, { ...opts, guest: true });
 }
 
@@ -59,7 +81,10 @@ export async function generateGuestTypes(witPath, opts) {
  * @param {TypeGenerationOptions} opts - options for controlling type generation
  * @returns {Promise<import('./transpile.js').FileBytes>}
  */
-export async function runTypesComponent(witPath, opts) {
+export async function runTypesComponent(
+    witPath: string,
+    opts: TypeGenerationOptions
+): Promise<import('./common.js').FileBytes> {
     await $initBindgenComponent;
     const name =
         opts.name ||


### PR DESCRIPTION
## Summary
- add FileBytes type and options interfaces
- annotate all functions in transpile sources with argument and return types

## Testing
- `npm run --workspace packages/jco-transpile tsc` *(fails: cannot find dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686cfb3677b8832c95f1bd9e3b855110